### PR TITLE
Display a fallback text if First reply or last reply is not available

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -180,12 +180,12 @@ function Home() {
 
       <div className="mt-2 rounded-xl bg-missive-light-border-color p-4">
         <div>
-          First reply on <span className="font-bold">{formatUnixTimestamp(conversation.first_reply)}</span>
+          First reply on <span className="font-bold">{conversation.first_reply ? formatUnixTimestamp(conversation.first_reply) : "N/A"}</span>
         </div>
         <div className="pt-2">
           Most recent reply on{' '}
           <span className="font-bold">
-            {formatUnixTimestamp(conversation.last_reply)}
+            {conversation.last_reply ? formatUnixTimestamp(conversation.last_reply) : "N/A"}
           </span>
         </div>
         <div className="pt-2 flex">


### PR DESCRIPTION
Co-authored-by: Thuan Ngo <thuan.ngo@eastagile.com>

[OUT-287](https://linear.app/pdw/issue/OUT-287/display-a-fallback-text-if-first-reply-or-last-reply-is-not-available)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for conversation timestamps
  - Added fallback display of "N/A" when first or last reply timestamps are missing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->